### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies


### PR DESCRIPTION
`Update .NET setup action to version 4`

Updated the `.NET` setup action in the `.github/workflows/dotnet.yml` file to use version `4` instead of `3`. This change ensures that the latest stable version of `.NET` is being used in the workflow.