### PR TITLE
update build yaml for new sq version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,25 +23,25 @@ jobs:
       - name: Cache SonarQube packages
         uses: actions/cache@v4
         with:
-          path: ~\.sonar\cache
+          path: ${{ runner.temp }}\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarQube scanner
         id: cache-sonar-scanner
         uses: actions/cache@v4
         with:
-          path: .\.sonar\scanner
+          path: ${{ runner.temp }}\scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Install SonarQube scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+          New-Item -Path ${{ runner.temp }}\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path ${{ runner.temp }}\scanner
       - name: Build and analyze
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"mgnoonan_RssFeeder_63c8414c-4bce-4f1b-b08d-509464912ae4" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}"
+          ${{ runner.temp }}\scanner\dotnet-sonarscanner begin /k:"mgnoonan_RssFeeder_d7328781-517b-4eb3-98f8-8335e2929a9a" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}"
           dotnet build
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          ${{ runner.temp }}\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
This pull request updates the SonarQube scanner setup in the GitHub Actions workflow to use the temporary runner directory instead of the project-specific `.sonar` folder. This helps avoid permission issues and ensures a cleaner build environment.

Workflow improvements:

* Changed SonarQube cache and scanner paths in `.github/workflows/build.yml` from `.sonar\cache` and `.sonar\scanner` to use `${{ runner.temp }}\cache` and `${{ runner.temp }}\scanner`, reducing the risk of permission errors and improving isolation.
* Updated all related commands in the workflow to reference the new scanner path, ensuring consistency throughout the build and analysis steps.
* Updated the SonarQube project key in the scanner command to the new value `mgnoonan_RssFeeder_d7328781-517b-4eb3-98f8-8335e2929a9a`.