### PR TITLE
Update video embed templates and YouTube iframe handling

### DIFF
--- a/RssFeeder.Console/Exporters/BaseArticleExporter.cs
+++ b/RssFeeder.Console/Exporters/BaseArticleExporter.cs
@@ -16,7 +16,7 @@ public class BaseArticleExporter
             case "youtube":
             case "youtu.be":
                 template = template.Replace("{class}", "");
-                template = template.Replace("{allow}", "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture");
+                template = template.Replace("{allow}", "");
                 break;
             case "rumble":
                 template = template.Replace("{class}", "rumble");

--- a/RssFeeder.Console/Exporters/ExportTemplates.cs
+++ b/RssFeeder.Console/Exporters/ExportTemplates.cs
@@ -29,7 +29,7 @@ public static class ExportTemplates
 $ArticleText$
 " + MetaDataTemplate;
 
-    public const string HtmlVideoTemplate = @"<iframe class=""{class}"" width=""$item.VideoWidth$"" height=""$item.VideoHeight$"" src=""$item.VideoUrl$"" frameborder=""0"" allow=""{allow}"" allowfullscreen></iframe>
+    public const string HtmlVideoTemplate = @"<iframe class=""{class}"" width=""$item.VideoWidth$"" height=""$item.VideoHeight$"" src=""$item.VideoUrl$"" allow=""{allow}"" allowfullscreen="""" referrerpolicy=""strict-origin-when-cross-origin"" style=""margin-top: 3rem; margin-bottom: 3rem; display: block""></iframe>
 <h3>$item.Subtitle$</h3>
 $ArticleText$
 " + MetaDataTemplate;


### PR DESCRIPTION
Update video embed templates and YouTube iframe handling

Refactored HtmlVideoTemplate to improve security and styling by adding referrerpolicy, inline styles, and explicit allowfullscreen. Removed frameborder and ensured allow attribute is always present. For YouTube embeds, the allow attribute is now omitted. Also, appended subtitle and article text after the iframe for consistency.